### PR TITLE
Documenting type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - ️🧐 Marking duplicated type name as invalid
 - ️🧐 Marking empty and invalid import as invalid
 - ✨ Comment code through shortcut
+- 📝 Documentation for type reference
 
 ### Fixed
 - Added missing top level keyword import

--- a/src/main/kotlin/com/github/alaanor/candid/psi/CandidElementFactory.kt
+++ b/src/main/kotlin/com/github/alaanor/candid/psi/CandidElementFactory.kt
@@ -19,6 +19,6 @@ object CandidElementFactory {
         return createDummyFile(project, "import \"$path\";")
     }
 
-    private fun createDummyFile(project: Project, text: String): CandidFile = PsiFileFactory.getInstance(project)
+    fun createDummyFile(project: Project, text: String): CandidFile = PsiFileFactory.getInstance(project)
         .createFileFromText("dummy.candid", CandidFileType.INSTANCE, text) as CandidFile
 }

--- a/src/main/kotlin/com/github/alaanor/candid/ui/CandidDocumentationProvider.kt
+++ b/src/main/kotlin/com/github/alaanor/candid/ui/CandidDocumentationProvider.kt
@@ -1,0 +1,34 @@
+package com.github.alaanor.candid.ui
+
+import com.github.alaanor.candid.CandidTypes
+import com.github.alaanor.candid.psi.CandidElementFactory
+import com.intellij.lang.documentation.DocumentationProvider
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+
+class CandidDocumentationProvider : DocumentationProvider {
+
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
+        val parent = originalElement?.parent ?: return null
+        return when(parent.elementType) {
+            CandidTypes.IDENTIFIER_REFERENCE -> candidTypeDoc(parent)
+            else -> null
+        }
+    }
+
+    private fun candidTypeDoc(element: PsiElement): String {
+        val declaration = element.reference?.resolve()
+            ?: return "Failed to resolve - no documentation available"
+
+        val project = element.project
+        val text = declaration.parent.text
+        return HtmlSyntaxInfoUtil.getHtmlContent(
+            CandidElementFactory.createDummyFile(project, text),
+            text, null,
+            EditorColorsManager.getInstance().globalScheme,
+            0, text.length
+        ).toString()
+    }
+}

--- a/src/main/kotlin/com/github/alaanor/candid/ui/CandidDocumentationProvider.kt
+++ b/src/main/kotlin/com/github/alaanor/candid/ui/CandidDocumentationProvider.kt
@@ -2,17 +2,20 @@ package com.github.alaanor.candid.ui
 
 import com.github.alaanor.candid.CandidTypes
 import com.github.alaanor.candid.psi.CandidElementFactory
+import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.lang.documentation.DocumentationProvider
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
 import com.intellij.psi.PsiElement
+import com.intellij.psi.TokenType
+import com.intellij.psi.presentation.java.SymbolPresentationUtil
 import com.intellij.psi.util.elementType
 
 class CandidDocumentationProvider : DocumentationProvider {
 
     override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
         val parent = originalElement?.parent ?: return null
-        return when(parent.elementType) {
+        return when (parent.elementType) {
             CandidTypes.IDENTIFIER_REFERENCE -> candidTypeDoc(parent)
             else -> null
         }
@@ -24,11 +27,54 @@ class CandidDocumentationProvider : DocumentationProvider {
 
         val project = element.project
         val text = declaration.parent.text
-        return HtmlSyntaxInfoUtil.getHtmlContent(
+
+        val commentDocumentation = getCommentDocumentation(declaration)
+        val fileLink = SymbolPresentationUtil.getFilePathPresentation(declaration.containingFile)
+        val definitionCode = HtmlSyntaxInfoUtil.getHtmlContent(
             CandidElementFactory.createDummyFile(project, text),
             text, null,
             EditorColorsManager.getInstance().globalScheme,
             0, text.length
         ).toString()
+
+        return buildString {
+            if (commentDocumentation != null) {
+                append(DocumentationMarkup.SECTIONS_START)
+                append(commentDocumentation)
+                append(DocumentationMarkup.SECTIONS_END)
+            }
+            append(DocumentationMarkup.DEFINITION_START)
+            append(definitionCode)
+            append(DocumentationMarkup.DEFINITION_END)
+            append(DocumentationMarkup.SECTIONS_START)
+            append(fileLink)
+            append(DocumentationMarkup.SECTIONS_END)
+        }
+    }
+
+    private fun getCommentDocumentation(declaration: PsiElement): String? {
+        val potentialWhitespace = declaration.parent.prevSibling ?: return null
+        if (potentialWhitespace.elementType != TokenType.WHITE_SPACE || potentialWhitespace.text.count { it == '\n' } != 1) {
+            return null
+        }
+
+        val potentialDocumentation = potentialWhitespace.prevSibling ?: return null
+        return when (potentialDocumentation.elementType) {
+            CandidTypes.LINE_COMMENT -> {
+                return potentialDocumentation.text
+                    .removePrefix("//")
+                    .trim()
+            }
+
+            CandidTypes.BLOCK_COMMENT -> {
+                return potentialDocumentation.text
+                    .removeSurrounding("/*", "*/")
+                    .lines()
+                    .joinToString("<br>") {
+                        it.trim().removePrefix("*").trim()
+                    }
+            }
+            else -> null
+        }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,6 +71,7 @@
         <stubIndex implementation="com.github.alaanor.candid.psi.stub.index.CandidStubTypeIndex"/>
 
         <include.provider implementation="com.github.alaanor.candid.index.CandidFileIncludeProvider"/>
+        <documentationProvider implementation="com.github.alaanor.candid.ui.CandidDocumentationProvider"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Provide documentation to all type reference, usually useful when hovering on it.

|normal scenario|
|-|
|![image](https://user-images.githubusercontent.com/8039130/169663510-c7cc2474-bb13-4250-aad9-790a350a17a6.png)|

|definition with user provided doc|
|-|
|![image](https://user-images.githubusercontent.com/8039130/169663438-3d530dda-c498-49fe-b55d-b21e55ab932e.png)|

|single line user doc|multi line user doc|
|-|-|
|![image](https://user-images.githubusercontent.com/8039130/169663441-67e8d707-2cd3-41af-a8d8-3e4384886f9b.png)|![image](https://user-images.githubusercontent.com/8039130/169663443-f02f076a-c862-48b4-91a5-4df494092750.png)|
