### PR TITLE
Bump intellij build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+## 0.3.6 - 2024-09-04
+
+### Fixed
+- Bump to 241.* version
+
 ## 0.3.5 - 2023-09-15
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@
 pluginGroup = com.github.alaanor.candid
 pluginName = candid-intellij-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.5
+pluginVersion = 0.3.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 232.*
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
- Update change log for new version
- Bump max build number for IDEA platforms (support for RustRover build 241.*)